### PR TITLE
Fixed Reagent Counter

### DIFF
--- a/Interface/AddOns/NDui/Modules/ActionBar/Bars/Bar1.lua
+++ b/Interface/AddOns/NDui/Modules/ActionBar/Bars/Bar1.lua
@@ -44,6 +44,8 @@ function Bar:GetActionCount(action)
 		local text = line:GetText()
 		local itemName = text and strmatch(text, REAGENTS_STRING)
 		if itemName then
+			itemName = itemName:gsub(":", "")
+            		itemName = itemName:match("^%s*(.+)")
 			return GetItemCount(itemName)
 		end
 	end


### PR DESCRIPTION
Now shows how many reagents you have for class specific abilities like Vanish or Blind instead of 0.

You can probably add that to the "REAGENTS_STRING" instead.

More about the fix:

The "itemName" variable returned something like ": Flash Powder" which means that the "GetItemCount" function won't be able to find the given item and just returns 0.